### PR TITLE
split parse into fromFile() and parse() method

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Our `app.js` may look like this:
 
 ```
 var nagioscfg2json = require('nagioscfg2json');
-nagioscfg2json.parse('localhost_nagios2.cfg', function (err, json){
+nagioscfg2json.fromFile('localhost_nagios2.cfg', function (err, json){
     if (err) {
 		console.log(err);
 		return;
@@ -80,6 +80,27 @@ Running our `app.js` from the commandline would result in the following output o
 ```
 
 This (though with a much larger output) also works on Nagios' objects.cache file.
+
+## API
+
+### parse(data, next)
+
+- Parameters:
+  - data: String of Nagios Object Configuration Text
+  - next: callback called upon parsing completion
+
+The callback will recieve following arguments:
+
+ - cfg : a Javascript Plain Object containing parsed configuration data
+
+### fromFile(filename,next)
+
+Convenience Method opening and reading configuration from a file and then
+turn it into a Plain Object.
+
+- Parameters:
+ - filename: File to read and subsequently parse
+ - next: callback function passed internally to parse method
 
 ## Installation
 

--- a/nagioscfg2json.js
+++ b/nagioscfg2json.js
@@ -3,7 +3,7 @@ module.exports = function (){
 
 	String.prototype.trim=function(){return this.replace(/^\s+|\s+$/g, '');};
 
-	function cfg2json (filename, next) {
+	function fromFile (filename, next) {
 
 		var fs = require('fs');
 		fs.readFile(filename, function (err, data){
@@ -11,47 +11,52 @@ module.exports = function (){
 				console.log(err);
 				return;
 			}
-			var txt = data.toString();
-			var lines = txt.split('\n');
-			var tag = '';
-			var service = {};
-			var cfg = {};
-
-			lines.forEach(function (data, i) {
-				var linetrim = lines[i].trim();
-				if (linetrim.indexOf('#')==0) return;
-				if (linetrim.length == 0) return;
-				var ss = data.split(/\s+/g);
-				if (ss.length > 0) {
-					if (ss[0] === 'define') {
-						// open tag
-						tag = ss[1].replace(/{/g, '');
-					} else if (ss.indexOf('}') >= 0){
-						// close tag
-						if (!eval('cfg.'+tag)) {
-							eval('cfg.'+tag+' = [];');
-						}
-						eval('cfg.'+tag+'.push(service);');
-						service = {};
-						tag = null;
-
-					} else {
-						if (ss.length > 1) {
-							if (tag) {
-								var i1 = lines[i].indexOf(ss[1])+ss[1].length;
-								eval('service.'+ss[1]+' = "'+lines[i].substr(i1, lines[i].length-i1).trim().replace(/"/g, '\\"').replace(/'/g, '\\\'')+'";');
-							}
-						}
-
-					}
-					// console.log(ss);
-				}
-			});
-			// console.log(('XXXXXXXXXXXXXXXXXXXXXXXX'));
-			next(cfg);
+			parse(data,next);
 		});
-	}
+	};
+
+       function parse (data,next) { 
+	   
+		var txt = data.toString();
+	        var lines = txt.split('\n');
+		var tag = '';
+		var service = {};
+		var cfg = {};
+
+		lines.forEach(function (data, i) {
+			var linetrim = lines[i].trim();
+			if (linetrim.indexOf('#')==0) return;
+			if (linetrim.length == 0) return;
+			
+			var ss = data.split(/\s+/g);
+			if (ss.length > 0) {
+				if (ss[0] === 'define') {
+					// open tag
+					tag = ss[1].replace(/{/g, '');
+				} else if (ss.indexOf('}') >= 0){
+					// close tag
+					if (!eval('cfg.'+tag)) {
+						eval('cfg.'+tag+' = [];');
+					}
+					eval('cfg.'+tag+'.push(service);');
+					service = {};
+					tag = null;
+
+				} else {
+					if (ss.length > 1) {
+						if (tag) {
+							var i1 = lines[i].indexOf(ss[1])+ss[1].length;
+							eval('service.'+ss[1]+' = "'+lines[i].substr(i1, lines[i].length-i1).trim().replace(/"/g, '\\"').replace(/'/g, '\\\'')+'";');
+						}
+					}
+				}
+			}
+		});
+		next(cfg);
+	};
+    
 	return {
-		parse: cfg2json
+	    parse: parse,
+	    fromFile: fromFile
 	}
 }();

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 var nagioscfg2json = require('./nagioscfg2json');
 
-nagioscfg2json.parse('./localhost_nagios2.cfg', function (err, json){
+nagioscfg2json.fromFile('./localhost_nagios2.cfg', function (err, json){
 	if (err) {
 		console.log(err);
 		return;


### PR DESCRIPTION
Since parse function previously expected a file to read the configuratin definition from it was very narrow in what it could do and not sensibly split up. 

`parse` now takes a String value that it'll turn into a JSON Object. Therefore allowing for a multitude of new sources from which to get and parse Configuration data. 

`fromFile` is now a convenience measure to still use the module to simply read a file and parse it. 

Calling conventions have not been altered extremely. 
